### PR TITLE
Add WhatsApp GPT integration base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # bot-printos
+
+Codigo base para integrar WhatsApp con ChatGPT usando Node.js.
+
+## Instalación
+
+1. Asegúrate de tener **Node.js** instalado.
+2. Clona este repositorio y ejecuta `npm install` para instalar las dependencias.
+3. Crea un archivo `.env` con tu clave de la API de OpenAI:
+
+```
+OPENAI_API_KEY=tu_clave
+```
+
+## Uso
+
+Ejecuta el bot con:
+
+```
+npm start
+```
+
+Se mostrará un código QR en la consola para vincular tu sesión de WhatsApp. Una vez escaneado, el bot responderá cada mensaje entrante utilizando la API de ChatGPT.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,40 @@
+require('dotenv').config();
+const { Client, LocalAuth } = require('whatsapp-web.js');
+const qrcode = require('qrcode-terminal');
+const { Configuration, OpenAIApi } = require('openai');
+
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+const openai = new OpenAIApi(configuration);
+
+const client = new Client({
+  authStrategy: new LocalAuth(),
+});
+
+client.on('qr', qr => {
+  qrcode.generate(qr, { small: true });
+  console.log('Scan the QR code above to log in.');
+});
+
+client.on('ready', () => {
+  console.log('WhatsApp client is ready!');
+});
+
+client.on('message', async msg => {
+  try {
+    if (msg.body) {
+      const response = await openai.createChatCompletion({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: msg.body }],
+      });
+      const reply = response.data.choices[0].message.content.trim();
+      msg.reply(reply);
+    }
+  } catch (err) {
+    console.error('Error getting response from OpenAI:', err.message);
+    msg.reply('Lo siento, hubo un error procesando tu mensaje.');
+  }
+});
+
+client.initialize();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bot-printos",
+  "version": "1.0.0",
+  "description": "WhatsApp integration using ChatGPT",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "whatsapp-web.js": "^1.21.1",
+    "qrcode-terminal": "^0.12.0",
+    "openai": "^3.1.0",
+    "dotenv": "^16.0.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add Node.js project scaffolding for a WhatsApp bot
- implement `index.js` with WhatsApp-Web and OpenAI integration
- include install and usage notes in README
- ignore node_modules and .env

## Testing
- `node index.js` *(fails: Cannot find module 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_6859bcbc31f8832bb572ef34e492fd5b